### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/signupdoctor/page.tsx
+++ b/src/app/signupdoctor/page.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 
 function RegisterDoctorPage() {
   const [imagePreviewUrl, setImagePreviewUrl] = useState<File>();
-  const [error, setError] = useState();
+  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -254,9 +254,23 @@ function RegisterDoctorPage() {
       hover:file:bg-blue-100"
                       type="file"
                       name="foto"
+                      accept="image/jpeg,image/png,image/gif,image/webp"
                       onChange={(e) => {
                         if (e.target.files && e.target.files.length > 0) {
-                          setImagePreviewUrl(e.target.files[0]);
+                          const file = e.target.files[0];
+                          const allowedTypes = [
+                            "image/jpeg",
+                            "image/png",
+                            "image/gif",
+                            "image/webp"
+                          ];
+                          if (allowedTypes.includes(file.type)) {
+                            setImagePreviewUrl(file);
+                            setError(null);
+                          } else {
+                            setImagePreviewUrl(undefined);
+                            setError("Solo se permiten imágenes JPEG, PNG, GIF o WEBP.");
+                          }
                         }
                       }}
                     />
@@ -265,8 +279,11 @@ function RegisterDoctorPage() {
                     {imagePreviewUrl && (
                       <img
                         src={URL.createObjectURL(imagePreviewUrl)}
-                        alt=""
+                        alt="Vista previa"
                         className="h-13 w-20 rounded-full"
+                    {error && (
+                      <p className="text-red-500 text-sm mt-2">{error}</p>
+                    )}
                       />
                     )}
                   </div>


### PR DESCRIPTION
Potential fix for [https://github.com/dawrin23/DoctorFind/security/code-scanning/1](https://github.com/dawrin23/DoctorFind/security/code-scanning/1)

To mitigate the risk, restrict the files that can be previewed and displayed in the `<img>` tag. The best fix is to only allow image files with MIME types that are safe for rendering (e.g., `image/jpeg`, `image/png`, `image/gif`, `image/webp`) and block or do not display SVGs (and possibly other formats containing active content) in the preview. Update the file input to accept only safe types and add code in the handler (`onChange`) to check the MIME type before setting `imagePreviewUrl`. If the file is not of an allowed type, do not update the preview and optionally show an error message.

- Update the `<input>` element's `accept` attribute to restrict file selection.
- Add a MIME type check before calling `setImagePreviewUrl`.
- Add optional error handling for invalid file types.

Edits occur around lines 256 and 257 (the `<input>`), 259 (the handler), and possibly error handling near line 11 (`error` state) and line 265-271 (the preview block).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
